### PR TITLE
Fix git-changelog config and update release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -25,13 +25,13 @@ Perform a full release for this project.
    git add CHANGELOG.md src/gale_shapley_algorithm/__init__.py
    git commit -m "chore: Release version X.Y.Z"
    ```
-7. Push, tag, and push the tag:
+7. Push, tag, push the tag, and create the GitHub release:
    ```bash
    git push
    git tag vX.Y.Z
    git push --tags
+   gh release create vX.Y.Z --generate-notes
    ```
-8. The GitHub Actions release workflow will automatically create a GitHub release from the tag.
 
 ## Important
 

--- a/config/git-changelog.toml
+++ b/config/git-changelog.toml
@@ -1,2 +1,2 @@
-[tool.git-changelog]
 convention = "angular"
+sections = ["feat", "fix", "refactor", "build", "deps", "perf"]


### PR DESCRIPTION
## Summary

- **Fix git-changelog config**: The standalone `config/git-changelog.toml` used `[tool.git-changelog]` table header (pyproject.toml syntax), which caused git-changelog to silently fall back to the `basic` convention with no sections filter. This is why `feat`, `refactor`, and other commit types were missing from generated changelogs. Standalone TOML config files need flat top-level keys.
- **Add explicit sections**: `feat`, `fix`, `refactor`, `build`, `deps`, `perf`
- **Update release skill**: Replace "GitHub Actions will auto-release" with explicit `gh release create --generate-notes`

## Test plan

- [x] Verified `read_config()` now returns `convention: angular` and `sections: [...]` correctly
- [x] Verified changelog output includes all `feat`, `fix`, and `refactor` commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)