### PR TITLE
feat: add Clear All button to GUI editor

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -138,6 +138,13 @@ function App() {
     setResponderPrefs(buildRandomPrefs(responderNames, proposerNames));
   }, [proposerNames, responderNames]);
 
+  const clearAll = useCallback(() => {
+    setProposerNames([]);
+    setResponderNames([]);
+    setProposerPrefs({});
+    setResponderPrefs({});
+  }, []);
+
   function buildRequest(): MatchingRequest {
     return {
       proposer_preferences: { ...proposerPrefs },
@@ -235,6 +242,7 @@ function App() {
               onReorderProposerPref={reorderProposerPref}
               onReorderResponderPref={reorderResponderPref}
               onRandomizePrefs={randomizePrefs}
+              onClearAll={clearAll}
               personImages={personImages}
               onUploadImage={uploadImage}
             />

--- a/frontend/src/components/PreferenceEditor.tsx
+++ b/frontend/src/components/PreferenceEditor.tsx
@@ -4,7 +4,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import { PersonList } from './PersonList';
 import { CompactPreferenceGrid } from './CompactPreferenceGrid';
-import { Shuffle } from 'lucide-react';
+import { Shuffle, Trash2 } from 'lucide-react';
 import type { PersonImages } from '@/types';
 
 interface PreferenceEditorProps {
@@ -19,6 +19,7 @@ interface PreferenceEditorProps {
   onReorderProposerPref: (person: string, newOrder: string[]) => void;
   onReorderResponderPref: (person: string, newOrder: string[]) => void;
   onRandomizePrefs: () => void;
+  onClearAll: () => void;
   personImages: PersonImages;
   onUploadImage: (name: string, file: File) => void;
 }
@@ -35,19 +36,29 @@ export function PreferenceEditor({
   onReorderProposerPref,
   onReorderResponderPref,
   onRandomizePrefs,
+  onClearAll,
   personImages,
   onUploadImage,
 }: PreferenceEditorProps) {
   const canRandomize = proposerNames.length > 0 && responderNames.length > 0;
+  const canClear = proposerNames.length > 0 || responderNames.length > 0;
 
   return (
     <div className="space-y-3">
-      {canRandomize && (
-        <div className="flex justify-center">
-          <Button variant="outline" size="sm" onClick={onRandomizePrefs}>
-            <Shuffle className="h-3.5 w-3.5 mr-1.5" />
-            Randomize Preferences
-          </Button>
+      {(canRandomize || canClear) && (
+        <div className="flex justify-center gap-2">
+          {canRandomize && (
+            <Button variant="outline" size="sm" onClick={onRandomizePrefs}>
+              <Shuffle className="h-3.5 w-3.5 mr-1.5" />
+              Randomize Preferences
+            </Button>
+          )}
+          {canClear && (
+            <Button variant="outline" size="sm" onClick={onClearAll}>
+              <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+              Clear All
+            </Button>
+          )}
         </div>
       )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- Adds a "Clear All" button next to "Randomize Preferences" in the GUI preference editor
- Resets all proposers, responders, and their preferences to an empty state when clicked
- Button uses the Trash2 icon and only appears when there are people to clear

Closes #29

## Test plan
- [ ] Verify the "Clear All" button appears when proposers or responders exist
- [ ] Verify clicking "Clear All" removes all proposers and responders
- [ ] Verify the button is hidden when the editor is already empty
- [ ] Verify "Randomize Preferences" button still works correctly alongside "Clear All"

🤖 Generated with [Claude Code](https://claude.com/claude-code)