### PR TITLE
fix: allow empty preference ranking in CLI

### DIFF
--- a/src/gale_shapley_algorithm/_cli/prompts.py
+++ b/src/gale_shapley_algorithm/_cli/prompts.py
@@ -65,7 +65,7 @@ def prompt_preferences(side_name: str, names: list[str], other_names: list[str])
 
         ranking = _prompt_ranking(name, other_names)
         preferences[name] = ranking
-        console.print(f"  → {name}: {' > '.join(ranking)}")
+        console.print(f"  → {name}: {' > '.join(ranking) if ranking else '(none)'}")
 
     return preferences
 
@@ -85,17 +85,18 @@ def _prompt_ranking(name: str, other_names: list[str]) -> list[str]:
     """
     example = ",".join(str(i) for i in range(1, len(other_names) + 1))
     while True:
-        raw = Prompt.ask(f"  Enter ranking for {name} (e.g. {example})")
+        raw = Prompt.ask(
+            f"  Enter ranking for {name} — only list acceptable matches (e.g. {example}), or press Enter for none"
+        )
         parts = [p.strip() for p in raw.split(",") if p.strip()]
+
+        if not parts:
+            return []
 
         try:
             indices = [int(p) for p in parts]
         except ValueError:
             console.print("  [red]Please enter comma-separated numbers.[/red]")
-            continue
-
-        if not indices:
-            console.print("  [red]Please enter at least one number.[/red]")
             continue
 
         if any(i < 1 or i > len(other_names) for i in indices):

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -196,13 +196,11 @@ class TestPromptRanking:
             result = _prompt_ranking("Alice", ["Bob", "Charlie"])
         assert result == ["Bob", "Charlie"]
 
-    def test_empty_retries(self) -> None:
-        with patch(
-            "gale_shapley_algorithm._cli.prompts.Prompt.ask",
-            side_effect=["", "1"],
-        ):
-            result = _prompt_ranking("Alice", ["Bob"])
-        assert result == ["Bob"]
+    def test_empty_returns_empty_list(self) -> None:
+        """Empty input returns an empty list (user prefers being unmatched)."""
+        with patch("gale_shapley_algorithm._cli.prompts.Prompt.ask", return_value=""):
+            result = _prompt_ranking("Alice", ["Bob", "Charlie"])
+        assert result == []
 
     def test_out_of_range_retries(self) -> None:
         with patch(


### PR DESCRIPTION
## Summary
- Allow empty input in `_prompt_ranking()` so users can express "prefers being unmatched" (empty preference list)
- Update prompt text to clarify that only acceptable matches should be listed, with option to press Enter for none
- Display `(none)` for empty rankings in the interactive preference summary

Closes #27

## Test plan
- [x] New test `test_empty_returns_empty_list` verifies empty input returns `[]`
- [x] Existing ranking tests still pass (partial, full, invalid input)
- [x] Ruff format and lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>