### PR TITLE
feat: run algorithm twice with --swap-sides

### DIFF
--- a/src/gale_shapley_algorithm/_cli/app.py
+++ b/src/gale_shapley_algorithm/_cli/app.py
@@ -87,12 +87,12 @@ def _generate_random_preferences(
 @app.command()
 def main(
     random_mode: bool = typer.Option(False, "--random", help="Generate random preferences"),
-    swap_sides: bool = typer.Option(False, "--swap-sides", help="Swap proposers and responders"),
+    swap_sides: bool = typer.Option(False, "--swap-sides", help="Run twice with swapped proposer/responder roles"),
 ) -> None:
     """Run the Gale-Shapley algorithm interactively.
 
     Supports manual preference entry or random generation (--random).
-    Use --swap-sides to reverse proposer/responder roles before matching.
+    Use --swap-sides to run the algorithm twice — once with each side proposing — and display both results.
     """
     try:
         console.print("\n[bold]Gale-Shapley Algorithm[/bold]\n")
@@ -108,14 +108,21 @@ def main(
             responder_prefs = prompt_preferences(responder_side, r_names, p_names)
 
         if swap_sides:
-            proposer_side, responder_side = responder_side, proposer_side
-            proposer_prefs, responder_prefs = responder_prefs, proposer_prefs
+            # Run 1: original sides
+            console.print(f"\n[bold]Result 1: {proposer_side} proposing[/bold]")
+            display_preferences(proposer_side, responder_side, proposer_prefs, responder_prefs)
+            result, stability = _run_matching(proposer_prefs, responder_prefs)
+            display_results(proposer_side, responder_side, result, stability)
 
-        display_preferences(proposer_side, responder_side, proposer_prefs, responder_prefs)
-
-        result, stability = _run_matching(proposer_prefs, responder_prefs)
-
-        display_results(proposer_side, responder_side, result, stability)
+            # Run 2: swapped sides
+            console.print(f"\n[bold]Result 2: {responder_side} proposing[/bold]")
+            display_preferences(responder_side, proposer_side, responder_prefs, proposer_prefs)
+            result, stability = _run_matching(responder_prefs, proposer_prefs)
+            display_results(responder_side, proposer_side, result, stability)
+        else:
+            display_preferences(proposer_side, responder_side, proposer_prefs, responder_prefs)
+            result, stability = _run_matching(proposer_prefs, responder_prefs)
+            display_results(proposer_side, responder_side, result, stability)
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted.[/yellow]")
         raise typer.Exit(code=130) from None

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -58,7 +58,7 @@ def test_cli_random_mode() -> None:
 
 
 def test_cli_swap_sides() -> None:
-    """Test CLI with --swap-sides flag."""
+    """Test CLI with --swap-sides runs algorithm twice and shows both results."""
     with (
         patch(
             "gale_shapley_algorithm._cli.app.prompt_side_names",
@@ -79,11 +79,13 @@ def test_cli_swap_sides() -> None:
         result = runner.invoke(app, ["--swap-sides"])
 
     assert result.exit_code == 0
-    assert "Matching Result" in result.output
+    assert "Men proposing" in result.output
+    assert "Women proposing" in result.output
+    assert result.output.count("Matching Result") == 2
 
 
 def test_cli_random_mode_with_swap() -> None:
-    """Test CLI in random mode with --swap-sides."""
+    """Test CLI in random mode with --swap-sides runs twice."""
     with patch(
         "gale_shapley_algorithm._cli.app.prompt_random_config",
         return_value=("Men", "Women", 2, 2),
@@ -91,7 +93,9 @@ def test_cli_random_mode_with_swap() -> None:
         result = runner.invoke(app, ["--random", "--swap-sides"])
 
     assert result.exit_code == 0
-    assert "Matching Result" in result.output
+    assert "Men proposing" in result.output
+    assert "Women proposing" in result.output
+    assert result.output.count("Matching Result") == 2
 
 
 def test_cli_keyboard_interrupt() -> None:


### PR DESCRIPTION
## Summary

- When `--swap-sides` is enabled, run the Gale-Shapley algorithm **twice** — once with the original proposer/responder assignment and once with swapped sides — displaying both results for comparison
- Each result set is labeled (e.g., "Result 1: Men proposing", "Result 2: Women proposing") with its own preference table and matching result
- Without `--swap-sides`, behavior is unchanged (single run)

Closes #26

## Test plan

- [x] Updated `test_cli_swap_sides` to verify both "Men proposing" and "Women proposing" appear in output and two "Matching Result" tables are rendered
- [x] Updated `test_cli_random_mode_with_swap` with the same dual-run assertions
- [x] All 98 tests pass
- [x] Format, lint, and typecheck all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)