### PR TITLE
docs: update How It Works dialog content

### DIFF
--- a/frontend/src/components/HowItWorksDialog.tsx
+++ b/frontend/src/components/HowItWorksDialog.tsx
@@ -24,7 +24,7 @@ export function HowItWorksDialog() {
             className="text-xl font-bold tracking-tight"
             style={{ fontFamily: "'DM Sans', system-ui, sans-serif" }}
           >
-            The Gale-Shapley Algorithm
+            The Gale–Shapley Algorithm
           </DialogTitle>
         </DialogHeader>
         <ScrollArea className="max-h-[70vh] px-6 pb-6 pt-4">
@@ -33,93 +33,81 @@ export function HowItWorksDialog() {
             style={{ fontFamily: "'DM Sans', system-ui, sans-serif" }}
           >
             <p>
-              Imagine a group of people on one side of a room, each holding a
-              private list of who they&rsquo;d most like to be paired with on the
-              other side. Everyone has ranked everyone else, and now a matchmaker
-              has to pair them up so that nobody wants to run off with someone
-              else&rsquo;s partner. That&rsquo;s the stable matching problem, and in 1962,
-              two mathematicians &mdash; David Gale and Lloyd Shapley &mdash; proved
-              something remarkable: a simple, elegant procedure always finds such
-              a matching.
+              In 1962, David Gale and Lloyd Shapley proved that a simple
+              procedure always produces a stable matching in a two-sided market.
+              Each participant on one side ranks everyone on the other side. The
+              algorithm runs in rounds. Every unmatched proposer applies to the
+              highest-ranked person they have not yet approached. Each responder
+              tentatively keeps the most preferred proposal received so far and
+              rejects the rest. Rejected proposers move to their next choice.
+              When no further proposals are made, the tentative matches become
+              final.
             </p>
 
             <p>
-              The algorithm works in rounds. In each round, every unmatched
-              proposer goes to the highest-ranked person on their list they
-              haven&rsquo;t yet asked, and proposes. Each responder looks at all the
-              proposals they received &mdash; including any tentative partner they&rsquo;re
-              already holding &mdash; keeps the one they like best, and lets the rest
-              go. Rejected proposers cross that name off their list and try again
-              next round. That&rsquo;s it. The process repeats until no one is left
-              proposing, and the tentative matches become final.
+              The result is stable: there is no blocking pair, meaning no two
+              participants who would both prefer each other over their assigned
+              partners. If the two sides differ in size, or if some matches are
+              unacceptable, some participants may remain unmatched. Stability
+              still holds in the formal sense, because no mutually preferred
+              feasible deviation exists.
             </p>
 
             <p>
-              What makes this beautiful is the guarantee. The result is always{' '}
-              <em>stable</em>, meaning there is no pair of people who would both
-              rather be with each other than with their assigned partner. In other
-              words, no one can point across the room and say &ldquo;we&rsquo;d both be
-              happier together&rdquo; &mdash; every such temptation is one-sided. This
-              holds regardless of how people rank each other, regardless of the
-              number of participants, every single time.
+              The procedure has a built-in asymmetry. When one side proposes, the
+              outcome is optimal for that side among all stable matchings and
+              least favorable for the responding side among stable matchings.
+              Switching who proposes produces a different stable allocation. The
+              algorithm does not determine which side benefits. That choice is
+              part of the mechanism design.
             </p>
 
             <p>
-              There&rsquo;s an asymmetry built in: the proposing side gets the best
-              stable partner they could hope for, while the responding side gets
-              their worst stable partner. Swap which side proposes, and you get a
-              different stable matching that favors the other group. Both are
-              equally valid. The algorithm doesn&rsquo;t decide who deserves the
-              advantage &mdash; only which stable outcome emerges.
-            </p>
-
-            <p className="border-l-2 border-primary/30 pl-4 text-foreground/70 italic">
-              In 2012, the Nobel Memorial Prize in Economics was awarded to Lloyd
-              Shapley and Alvin Roth &ldquo;for the theory of stable allocations and
-              the practice of market design.&rdquo; Shapley for the theory behind this
-              very algorithm, and Roth for spending decades showing the world what
-              it could do.
+              In 2012, Lloyd Shapley and Alvin Roth received the Nobel Memorial
+              Prize in Economic Sciences for the theory of stable allocations and
+              the practice of market design. Shapley developed the theoretical
+              foundations. Roth extended them to real institutions.
             </p>
 
             <p>
-              Roth discovered that the National Resident Matching Program, which
-              assigns medical school graduates to hospital residencies across the
-              United States, had independently reinvented something essentially
-              identical to Gale-Shapley in the 1950s &mdash; before the paper was
-              even published. He then helped redesign it when the original system
-              started breaking down under modern pressures like couples applying
-              together.
+              A centralized system for assigning U.S. medical graduates to
+              residencies emerged in the early 1950s and was formalized as the
+              National Resident Matching Program. Decades later, Roth and
+              collaborators analyzed it through the lens of deferred acceptance
+              and helped redesign it in the late 1990s to better handle modern
+              constraints, including couples applying jointly. The updated
+              mechanism aligned the program more closely with the
+              applicant-proposing version of deferred acceptance.
             </p>
 
             <p>
-              But his most celebrated work came in kidney exchange. When a patient
-              needs a kidney and a loved one volunteers to donate but isn&rsquo;t a
-              biological match, Roth helped design exchange systems where
-              incompatible pairs could be matched in cycles &mdash; your donor gives
-              to my patient, my donor gives to yours &mdash; using the same
-              principles of stability. Thousands of people have received
-              transplants through these programs who otherwise would have waited
-              years on the deceased-donor list, or never received one at all.
+              Kidney exchange required a different technical extension.
+              Incompatible donor–patient pairs form a directed compatibility
+              graph. Clearinghouses search for disjoint cycles and chains that
+              satisfy medical and logistical constraints, often optimizing for the
+              number of transplants. Although the structure differs from
+              one-to-one matching, the underlying discipline is the same: explicit
+              preferences, clear rules, and a centralized algorithm that prevents
+              mutually beneficial side deals. These exchanges have enabled
+              thousands of additional transplants.
             </p>
 
             <p>
-              The same ideas now run school choice systems in New York, Boston,
-              and cities around the world, where families rank schools and schools
-              rank applicants, and an algorithm finds an assignment where no
-              student and school would both prefer each other over their current
-              match. Before these systems, the assignment process in New York City
-              was so broken that roughly 30,000 students a year ended up at
-              schools they hadn&rsquo;t even listed.
+              Similar ideas reshaped public school assignment in cities such as
+              New York and Boston. Families submit ranked lists of schools.
+              Schools apply priority rules based on criteria such as siblings or
+              location. The redesigned systems reduced strategic gaming and
+              sharply lowered the number of students assigned to schools they had
+              not listed under the prior process.
             </p>
 
             <p>
-              What started as a short, elegant proof about an abstract matching
-              problem became one of the most practically consequential ideas in
-              modern economics. The core insight is disarmingly simple: let people
-              express their preferences honestly, run a transparent process, and
-              the result is something no pair can improve upon by going around the
-              system. It&rsquo;s a rare case where mathematical beauty and real-world
-              usefulness turned out to be the same thing.
+              What began as an abstract proof about stable allocations became a
+              framework for allocating scarce resources in labor markets,
+              education systems, and organ exchange. The core logic remains
+              unchanged: collect preferences, apply a well-specified procedure,
+              and produce an allocation that no pair can jointly improve upon
+              outside the mechanism.
             </p>
           </div>
         </ScrollArea>


### PR DESCRIPTION
## Summary
- Rewrites the "How It Works" dialog in the GUI frontend with updated, more factual content
- Updates the title to use the proper en-dash in "Gale–Shapley"
- Replaces the 9 original paragraphs with 8 new paragraphs covering: the algorithm procedure, stability guarantees, proposer-side optimality, the 2012 Nobel Prize, NRMP, kidney exchange, school choice, and a concluding summary
- Removes the special styling on the Nobel Prize paragraph (no longer a blockquote)

## Test plan
- [x] Frontend builds successfully (`npm run build`)
- [x] Backend format/lint/typecheck passes (`task fix` and `task ci`)
- [ ] Manually verify dialog renders correctly in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)