### PR TITLE
fix: remove default Vite favicon causing 404

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" href="data:," />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- Replace the missing `/vite.svg` favicon reference in `frontend/index.html` with an empty data URI (`data:,`)
- Eliminates the `404 Not Found` logged on every page load

## Test plan
- [ ] Run the GUI and confirm no `/vite.svg` 404 in backend logs
- [ ] Confirm browser tab shows no broken favicon indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)