### PR TITLE
feat(numeric): add gale_shapley_traced with proposal stats and selector hook

### DIFF
--- a/src/gale_shapley_algorithm/numeric/__init__.py
+++ b/src/gale_shapley_algorithm/numeric/__init__.py
@@ -30,7 +30,19 @@ Example:
     >>> lattice = enumerate_stable_matchings(proposer_rank, responder_rank)
 """
 
-from gale_shapley_algorithm.numeric.gs import gale_shapley, men_optimal_gs, women_optimal_gs
+from gale_shapley_algorithm.numeric.gs import (
+    GSStats,
+    Selector,
+    fifo_selector,
+    gale_shapley,
+    gale_shapley_traced,
+    lifo_selector,
+    men_optimal_gs,
+    men_optimal_traced,
+    random_selector,
+    women_optimal_gs,
+    women_optimal_traced,
+)
 from gale_shapley_algorithm.numeric.lattice import (
     apply_rotation,
     enumerate_stable_matchings,
@@ -39,12 +51,20 @@ from gale_shapley_algorithm.numeric.lattice import (
 from gale_shapley_algorithm.numeric.stability import find_blocking_pairs, is_stable
 
 __all__ = [
+    "GSStats",
+    "Selector",
     "apply_rotation",
     "enumerate_stable_matchings",
     "exposed_rotations",
+    "fifo_selector",
     "find_blocking_pairs",
     "gale_shapley",
+    "gale_shapley_traced",
     "is_stable",
+    "lifo_selector",
     "men_optimal_gs",
+    "men_optimal_traced",
+    "random_selector",
     "women_optimal_gs",
+    "women_optimal_traced",
 ]

--- a/src/gale_shapley_algorithm/numeric/gs.py
+++ b/src/gale_shapley_algorithm/numeric/gs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 try:
@@ -14,6 +16,76 @@ except ImportError as e:  # pragma: no cover
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+
+type Selector = Callable[[Sequence[int]], int]
+"""Picks which free proposer goes next.
+
+Receives the current free list of proposer ids and returns an index into
+that list (``0..len(free)-1``; negative indices supported per ``list.pop``
+semantics). The default is :func:`lifo_selector`, which matches the
+historical behavior of :func:`gale_shapley` (``free.pop()``).
+"""
+
+
+def lifo_selector(free: Sequence[int]) -> int:
+    """Return the last index — equivalent to ``list.pop()`` (LIFO)."""
+    del free
+    return -1
+
+
+def fifo_selector(free: Sequence[int]) -> int:
+    """Return the first index — pops in arrival order (FIFO)."""
+    del free
+    return 0
+
+
+def random_selector(rng: np.random.Generator) -> Selector:
+    """Build a uniform-random selector backed by a numpy ``Generator``.
+
+    Roth-Vande Vate-style: pick a free proposer uniformly at random each step.
+    Final matching is invariant to selector choice (Knuth's order independence)
+    but the proposal count is not — random order is a useful baseline against
+    LIFO/FIFO for amortized analysis.
+
+    Args:
+        rng: a numpy ``Generator`` (use ``np.random.default_rng(seed)`` for
+            determinism).
+
+    Returns:
+        A :data:`Selector` closure that draws ``rng.integers(len(free))`` per call.
+    """
+
+    def _selector(free: Sequence[int]) -> int:
+        return int(rng.integers(len(free)))
+
+    return _selector
+
+
+@dataclass(slots=True, frozen=True, eq=False)
+class GSStats:
+    """Result of a traced Gale-Shapley run.
+
+    ``eq=False`` because :attr:`match` and :attr:`proposals_per_proposer` are
+    numpy arrays whose ``__eq__`` returns an array, not a bool — so the
+    dataclass-generated ``__eq__`` would raise. Compare fields directly.
+
+    Attributes:
+        match: shape ``(n,)``, dtype ``int16``. Proposer-indexed:
+            ``match[p]`` is the responder paired with proposer ``p``. The
+            wrapper :func:`women_optimal_traced` re-indexes this to be
+            men-indexed; see its docstring.
+        proposals: total number of proposal events. Equals
+            ``proposals_per_proposer.sum()``.
+        proposals_per_proposer: shape ``(n,)``, dtype ``int16``.
+            ``proposals_per_proposer[p]`` is the number of proposals made by
+            proposer ``p``, which also equals the rank (1-indexed) of ``p``'s
+            final match in ``p``'s preference list.
+    """
+
+    match: NDArray[np.int16]
+    proposals: int
+    proposals_per_proposer: NDArray[np.int16]
 
 
 def _validate_rank_matrices(
@@ -47,6 +119,61 @@ def _validate_rank_matrices(
             )
 
 
+def gale_shapley_traced(
+    proposer_rank: NDArray[np.integer],
+    responder_rank: NDArray[np.integer],
+    *,
+    selector: Selector = lifo_selector,
+) -> GSStats:
+    """Run proposer-optimal deferred acceptance and return per-proposer statistics.
+
+    Mechanically identical to :func:`gale_shapley` (sequential McVitie-Wilson
+    on the free-proposer pool), but exposes the proposal count and a
+    pluggable proposer-selection rule. The final matching is invariant under
+    selector choice (Knuth); the proposal count is not.
+
+    Args:
+        proposer_rank: ``(n, n)`` array where ``proposer_rank[i, j]`` is
+            the 1-indexed position of responder ``j`` in proposer ``i``'s
+            preference list. Each row must be a permutation of ``1..n``.
+        responder_rank: ``(n, n)`` array with the symmetric convention.
+        selector: picks which free proposer acts next; defaults to
+            :func:`lifo_selector`. See :data:`Selector`.
+
+    Returns:
+        :class:`GSStats` with the matching, total proposal count, and
+        per-proposer counts.
+
+    Raises:
+        ValueError: if the two arrays don't have the same square shape, or
+            any row is not a permutation of ``1..n``.
+        IndexError: if ``selector`` returns an index outside the free list.
+    """
+    _validate_rank_matrices(proposer_rank, responder_rank)
+    n = proposer_rank.shape[0]
+    next_proposal = np.zeros(n, dtype=np.int16)
+    responder_match = np.full(n, -1, dtype=np.int16)
+    proposer_pref = np.argsort(proposer_rank, axis=1).astype(np.int16)
+    free: list[int] = list(range(n))
+    while free:
+        p = free.pop(selector(free))
+        r = int(proposer_pref[p, next_proposal[p]])
+        next_proposal[p] += 1
+        current = int(responder_match[r])
+        if current == -1:
+            responder_match[r] = p
+        elif responder_rank[r, p] < responder_rank[r, current]:
+            responder_match[r] = p
+            free.append(current)
+        else:
+            free.append(p)
+    return GSStats(
+        match=np.argsort(responder_match).astype(np.int16),
+        proposals=int(next_proposal.sum()),
+        proposals_per_proposer=next_proposal.copy(),
+    )
+
+
 def gale_shapley(proposer_rank: NDArray[np.integer], responder_rank: NDArray[np.integer]) -> NDArray[np.int16]:
     """Run proposer-optimal deferred acceptance.
 
@@ -64,25 +191,7 @@ def gale_shapley(proposer_rank: NDArray[np.integer], responder_rank: NDArray[np.
         ValueError: if the two arrays don't have the same square shape, or
             any row is not a permutation of ``1..n``.
     """
-    _validate_rank_matrices(proposer_rank, responder_rank)
-    n = proposer_rank.shape[0]
-    next_proposal = np.zeros(n, dtype=np.int16)
-    responder_match = np.full(n, -1, dtype=np.int16)
-    proposer_pref = np.argsort(proposer_rank, axis=1).astype(np.int16)
-    free = list(range(n))
-    while free:
-        p = free.pop()
-        r = int(proposer_pref[p, next_proposal[p]])
-        next_proposal[p] += 1
-        current = int(responder_match[r])
-        if current == -1:
-            responder_match[r] = p
-        elif responder_rank[r, p] < responder_rank[r, current]:
-            responder_match[r] = p
-            free.append(current)
-        else:
-            free.append(p)
-    return np.argsort(responder_match).astype(np.int16)
+    return gale_shapley_traced(proposer_rank, responder_rank).match
 
 
 def men_optimal_gs(men_rank: NDArray[np.integer], women_rank: NDArray[np.integer]) -> NDArray[np.int16]:
@@ -93,3 +202,57 @@ def men_optimal_gs(men_rank: NDArray[np.integer], women_rank: NDArray[np.integer
 def women_optimal_gs(men_rank: NDArray[np.integer], women_rank: NDArray[np.integer]) -> NDArray[np.int16]:
     """Return the women-optimal stable matching, still in men-indexed form ``match[m] = w``."""
     return np.argsort(gale_shapley(women_rank, men_rank)).astype(np.int16)
+
+
+def men_optimal_traced(
+    men_rank: NDArray[np.integer],
+    women_rank: NDArray[np.integer],
+    *,
+    selector: Selector = lifo_selector,
+) -> GSStats:
+    """Men-optimal stable matching with per-man proposal stats.
+
+    Equivalent to ``gale_shapley_traced(men_rank, women_rank, selector=...)``;
+    provided for symmetry with :func:`men_optimal_gs`.
+
+    Args:
+        men_rank: ``(n, n)`` rank matrix for men (proposers).
+        women_rank: ``(n, n)`` rank matrix for women (responders).
+        selector: see :data:`Selector`.
+
+    Returns:
+        :class:`GSStats` where ``match`` and ``proposals_per_proposer`` are
+        both men-indexed.
+    """
+    return gale_shapley_traced(men_rank, women_rank, selector=selector)
+
+
+def women_optimal_traced(
+    men_rank: NDArray[np.integer],
+    women_rank: NDArray[np.integer],
+    *,
+    selector: Selector = lifo_selector,
+) -> GSStats:
+    """Women-optimal stable matching with per-woman proposal stats.
+
+    Runs :func:`gale_shapley_traced` with women as the proposing side. The
+    returned ``match`` is re-indexed to men-indexed form for consistency with
+    :func:`women_optimal_gs`. ``proposals_per_proposer`` remains
+    **women-indexed**, since women are the proposers in this run.
+
+    Args:
+        men_rank: ``(n, n)`` rank matrix for men.
+        women_rank: ``(n, n)`` rank matrix for women.
+        selector: see :data:`Selector`.
+
+    Returns:
+        :class:`GSStats` with ``match[m] = w`` (men-indexed) and
+        ``proposals_per_proposer[w] = number of proposals woman w made``
+        (women-indexed). ``proposals`` is the unambiguous total.
+    """
+    stats = gale_shapley_traced(women_rank, men_rank, selector=selector)
+    return GSStats(
+        match=np.argsort(stats.match).astype(np.int16),
+        proposals=stats.proposals,
+        proposals_per_proposer=stats.proposals_per_proposer,
+    )

--- a/tests/numeric_test.py
+++ b/tests/numeric_test.py
@@ -15,14 +15,21 @@ import pytest
 
 from gale_shapley_algorithm import Algorithm, Proposer, Responder
 from gale_shapley_algorithm.numeric import (
+    GSStats,
     apply_rotation,
     enumerate_stable_matchings,
     exposed_rotations,
+    fifo_selector,
     find_blocking_pairs,
     gale_shapley,
+    gale_shapley_traced,
     is_stable,
+    lifo_selector,
     men_optimal_gs,
+    men_optimal_traced,
+    random_selector,
     women_optimal_gs,
+    women_optimal_traced,
 )
 from gale_shapley_algorithm.numeric.stability import is_stable_batch
 
@@ -263,3 +270,141 @@ def test_apply_rotation_does_not_mutate_input(rng: np.random.Generator) -> None:
         _ = apply_rotation(mo, rotations[0])
         assert np.array_equal(mo, mo_copy)
         assert np.array_equal(rotations[0], rotation_copy)
+
+
+# --- traced GS API -----------------------------------------------------------
+
+
+def _same_prefs_instance(n: int) -> tuple[np.ndarray, np.ndarray]:
+    """All proposers share one ranking of responders, and vice versa: the
+    pathological clustering case where men-MW makes ``n*(n+1)/2`` proposals."""
+    rank = np.tile(np.arange(1, n + 1, dtype=np.int16), (n, 1))
+    return rank, rank.copy()
+
+
+def test_traced_match_equals_gale_shapley(rng: np.random.Generator) -> None:
+    """gale_shapley_traced.match must agree with the historical gale_shapley."""
+    for _ in range(20):
+        men, women = _random_instance(6, rng)
+        stats = gale_shapley_traced(men, women)
+        assert np.array_equal(stats.match, gale_shapley(men, women))
+
+
+def test_traced_returns_gsstats(rng: np.random.Generator) -> None:
+    men, women = _random_instance(5, rng)
+    stats = gale_shapley_traced(men, women)
+    assert isinstance(stats, GSStats)
+
+
+def test_traced_proposals_equals_per_proposer_sum(rng: np.random.Generator) -> None:
+    for _ in range(20):
+        men, women = _random_instance(7, rng)
+        stats = gale_shapley_traced(men, women)
+        assert stats.proposals == int(stats.proposals_per_proposer.sum())
+
+
+def test_traced_proposals_per_proposer_is_match_rank(rng: np.random.Generator) -> None:
+    """Each proposer's count equals the 1-indexed rank of their final match."""
+    for _ in range(20):
+        men, women = _random_instance(6, rng)
+        stats = gale_shapley_traced(men, women)
+        for p in range(stats.match.shape[0]):
+            r = int(stats.match[p])
+            assert int(stats.proposals_per_proposer[p]) == int(men[p, r])
+
+
+def test_traced_match_invariant_under_selector(rng: np.random.Generator) -> None:
+    """Knuth: proposer-optimal matching is invariant to proposer order."""
+    selector_rng = np.random.default_rng(123)
+    for _ in range(15):
+        men, women = _random_instance(7, rng)
+        lifo = gale_shapley_traced(men, women, selector=lifo_selector).match
+        fifo = gale_shapley_traced(men, women, selector=fifo_selector).match
+        rand = gale_shapley_traced(men, women, selector=random_selector(selector_rng)).match
+        assert np.array_equal(lifo, fifo)
+        assert np.array_equal(lifo, rand)
+
+
+def test_traced_proposal_count_invariant_under_selector(rng: np.random.Generator) -> None:
+    """One-sided M-W: total proposals depend only on the final match (which is
+    Knuth-invariant), so the count is also invariant under selector choice."""
+    selector_rng = np.random.default_rng(7)
+    for _ in range(15):
+        men, women = _random_instance(7, rng)
+        lifo = gale_shapley_traced(men, women, selector=lifo_selector).proposals
+        fifo = gale_shapley_traced(men, women, selector=fifo_selector).proposals
+        rand = gale_shapley_traced(men, women, selector=random_selector(selector_rng)).proposals
+        assert lifo == fifo == rand
+
+
+@pytest.mark.parametrize("n", [2, 3, 4, 5, 6, 8])
+def test_traced_same_prefs_is_quadratic(n: int) -> None:
+    """When every proposer shares one ranking and every responder shares one
+    ranking, men-MW makes exactly ``1+2+...+n = n*(n+1)/2`` proposals — the
+    canonical worst case that motivates this work."""
+    p_rank, r_rank = _same_prefs_instance(n)
+    stats = gale_shapley_traced(p_rank, r_rank)
+    assert stats.proposals == n * (n + 1) // 2
+    assert np.array_equal(stats.match, np.arange(n, dtype=np.int16))
+
+
+def test_random_selector_terminates_and_is_stable(rng: np.random.Generator) -> None:
+    selector_rng = np.random.default_rng(42)
+    selector = random_selector(selector_rng)
+    for _ in range(10):
+        men, women = _random_instance(8, rng)
+        stats = gale_shapley_traced(men, women, selector=selector)
+        assert is_stable(men, women, stats.match)
+
+
+def test_men_optimal_traced_delegates(rng: np.random.Generator) -> None:
+    men, women = _random_instance(6, rng)
+    via_wrapper = men_optimal_traced(men, women)
+    via_primitive = gale_shapley_traced(men, women)
+    assert np.array_equal(via_wrapper.match, via_primitive.match)
+    assert via_wrapper.proposals == via_primitive.proposals
+
+
+def test_women_optimal_traced_match_matches_women_optimal_gs(rng: np.random.Generator) -> None:
+    """women_optimal_traced.match must equal women_optimal_gs (men-indexed)."""
+    for _ in range(10):
+        men, women = _random_instance(6, rng)
+        traced = women_optimal_traced(men, women)
+        legacy = women_optimal_gs(men, women)
+        assert np.array_equal(traced.match, legacy)
+        assert is_stable(men, women, traced.match)
+
+
+def test_women_optimal_traced_per_proposer_indexed_by_woman(rng: np.random.Generator) -> None:
+    """proposals_per_proposer in women_optimal_traced is indexed by woman, so
+    woman w's count equals the rank of her partner in her own preference list."""
+    men, women = _random_instance(6, rng)
+    traced = women_optimal_traced(men, women)
+    n = traced.match.shape[0]
+    for w in range(n):
+        partner_m = int(np.argwhere(traced.match == w)[0, 0])
+        assert int(traced.proposals_per_proposer[w]) == int(women[w, partner_m])
+
+
+def test_women_optimal_traced_proposals_total(rng: np.random.Generator) -> None:
+    men, women = _random_instance(6, rng)
+    traced = women_optimal_traced(men, women)
+    assert traced.proposals == int(traced.proposals_per_proposer.sum())
+
+
+def test_traced_validates_inputs() -> None:
+    """Validation should run before the loop, same as gale_shapley."""
+    bad = np.array([[1, 1, 2], [1, 2, 3], [3, 2, 1]], dtype=np.int16)
+    good = np.array([[1, 2, 3], [2, 3, 1], [3, 1, 2]], dtype=np.int16)
+    with pytest.raises(ValueError, match="permutation"):
+        gale_shapley_traced(bad, good)
+
+
+def test_lifo_and_fifo_selectors_are_pure() -> None:
+    """The default selectors don't read or mutate the free list contents."""
+    assert lifo_selector([0, 1, 2]) == -1
+    assert fifo_selector([0, 1, 2]) == 0
+    free = [4, 5, 6]
+    _ = lifo_selector(free)
+    _ = fifo_selector(free)
+    assert free == [4, 5, 6]


### PR DESCRIPTION
## Summary

Expose **proposal counts** and a **pluggable proposer-selection rule** on the numpy-backed M-W loop in `numeric/gs.py`. Motivated by downstream RL work that needs deferred-acceptance baselines for the \"can we reach a stable matching with fewer proposals?\" question — but the additions are stand-alone and useful for any caller who wants per-proposer instrumentation.

### Added

| Symbol | Purpose |
|--------|---------|
| `GSStats` | Frozen dataclass: `match`, `proposals`, `proposals_per_proposer`. `eq=False` so the array fields don't break `__eq__`. |
| `Selector` (`type` alias) | `Callable[[Sequence[int]], int]` — receives the free list, returns an index. |
| `lifo_selector` | Returns `-1`. Matches the historical `free.pop()` behavior — chosen as the default for backward compat. |
| `fifo_selector` | Returns `0`. Useful as a baseline. |
| `random_selector(rng)` | Factory returning a selector backed by an `np.random.Generator` — Roth-Vande Vate-style uniform pick. |
| `gale_shapley_traced(p_rank, r_rank, *, selector=lifo_selector) -> GSStats` | Same M-W loop as `gale_shapley`, returns the stats. |
| `men_optimal_traced` / `women_optimal_traced` | Convenience wrappers mirroring `men_optimal_gs` / `women_optimal_gs` orientation conventions. |

### Refactor

`gale_shapley` is now a one-liner: `return gale_shapley_traced(p, r).match`. Behavior unchanged.

### Orientation note for `women_optimal_traced`

Same convention as `women_optimal_gs`: `match` is **men-indexed** (`match[m] = w`). But `proposals_per_proposer` is **women-indexed** — women are the proposers in this run, so per-proposer stats are most natural in that orientation. Documented on the function.

### Why now

The proposer-optimal matching is invariant under selector choice (Knuth), and so is the total proposal count for one-sided M-W (it equals `sum_i rank_i(match_i)`). So none of the included selectors *win* against the default — they're identical. The selector hook is there for callers (RL agents, custom heuristics, randomized analyses) that want to drive the loop themselves. Tests verify the invariance.

### Test plan

- [x] `gale_shapley_traced.match` agrees with `gale_shapley` on random instances
- [x] `proposals == proposals_per_proposer.sum()`
- [x] `proposals_per_proposer[p]` equals the 1-indexed rank of `p`'s match in `p`'s preference list
- [x] Match invariant under LIFO / FIFO / random selectors (Knuth)
- [x] Proposal count invariant under selector for one-sided M-W
- [x] Pathological all-same-prefs case: `proposals == n*(n+1)/2` for n in {2..8}
- [x] Random selector terminates and yields a stable matching
- [x] `women_optimal_traced.match` equals `women_optimal_gs`
- [x] `women_optimal_traced` per-proposer stats are women-indexed
- [x] Validation runs in `_traced` (rejects non-permutation rows)
- [x] `lifo_selector` / `fifo_selector` are pure
- [x] `task ci` green: 140 tests, 98.47% total coverage, `numeric/gs.py` at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)