### PR TITLE
build(deps): override ip-address >=10.1.1 in frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5683,9 +5683,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,5 +38,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.4",
     "vite": "^8.0.13"
+  },
+  "overrides": {
+    "ip-address": "^10.1.1"
   }
 }


### PR DESCRIPTION
## Summary

- Adds an npm `overrides` entry forcing `ip-address >=10.1.1` to close the last open Dependabot alert (GHSA XSS in `Address6` HTML-emitting methods).
- Source of the vuln was a transitive chain through the `shadcn` install-CLI: `shadcn → @modelcontextprotocol/sdk → express-rate-limit → ip-address@10.1.0`. Shadcn is install-time only and never ships in the production bundle, so real-world exposure was nil — this just clears the alert without waiting for `express-rate-limit` upstream to bump its dep.

## Test plan

- [x] `npm run build` in `frontend/` succeeds
- [x] `npm audit` no longer reports `ip-address`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)